### PR TITLE
Update node version to LTS; Add python3 support

### DIFF
--- a/docker/tester/Dockerfile-310
+++ b/docker/tester/Dockerfile-310
@@ -1,4 +1,4 @@
-FROM node:6.3.0
+FROM node:8.9.3
 MAINTAINER Nick Bradley <nbrad11@cs.ubc.ca>
 
 ARG deliverable
@@ -18,6 +18,8 @@ ENV IS_CONTAINER_LIVE=1
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb http://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN echo "deb http://ftp.debian.org/debian testing main" >> /etc/apt/sources.list
+RUN echo 'APT::Default-Release "jessie";' | tee -a /etc/apt/apt.conf.d/00local
 
 RUN apt-get update
 RUN apt-get -y install iptables
@@ -26,6 +28,13 @@ RUN apt-get -y install yarn
 RUN apt-get -y install python-pip
 RUN pip install requests
 RUN apt-get -y install nano
+RUN apt-get -y -t testing install python3
+RUN apt-get -y -t testing install python3-pip
+# needed to build python-iptables for some reason. see https://github.com/pyca/cryptography/issues/3697
+RUN apt-get -y -t testing install libdpkg-perl
+RUN pip3 install python-iptables
+RUN pip3 install https://github.com/theskumar/python-dotenv/archive/v0.7.1.tar.gz
+RUN pip3 install checksumdir
 
 COPY pull-repo.sh /pull-repo.sh
 COPY run-tests-310.sh /run-tests.sh


### PR DESCRIPTION
Changed the container's Node version to the latest LTS (8.9.3). This will simplify deployment since the student's project requires node 8.9.X.

The scripts that grade the student's projects have been migrated from bash to python (version 3) scripts. To support this transition, I have added install commands for python3 (version 3.6 from the debian testing branch) and pip3. This should not impact existing scripts since the command `python3` must be used to execute scripts under version 3.

Some additional python packages are required to support the grading scripts. They have been added to the Dockerfile to take advantage of caching but it is not ideal since other TAs will probably need to add additional packages but they don;t have access to this repo. This current approach (in the PR) will do for now though.