### PR TITLE
Bug fix/non processed counted as request

### DIFF
--- a/src/controller/github/CommitCommentController.ts
+++ b/src/controller/github/CommitCommentController.ts
@@ -150,6 +150,8 @@ export default class CommitCommentContoller {
                 if (githubGradeComment.getPostbackOnComplete()) {
                   // postback on complete is a freebie, such as if a build fails, and does not count as a request even if they make a request
                   record.setIsProcessed(false); 
+                } else {
+                  record.setIsProcessed(true);
                 }
                 let githubFeedback: string = await githubGradeComment.formatResult();
                 response = {

--- a/src/model/requests/CommitComment.ts
+++ b/src/model/requests/CommitComment.ts
@@ -84,7 +84,7 @@ export default class CommitCommentRecord {
         that.message = payload.comment.body;
 
         that.isRequest = payload.comment.body.toLowerCase().includes(this.config.getMentionTag());
-        that.isProcessed = true;
+        that.isProcessed = false;
         if (that.isRequest) {
           that.options = this.extractOptions(this.message);
           let reqDeliverable: string = this.options[0];//that.extractDeliverable(that.message);

--- a/src/repos/TestRecordRepo.ts
+++ b/src/repos/TestRecordRepo.ts
@@ -24,4 +24,4 @@ export default class TestRecordRepo {
 
 
 
-}
+}   


### PR DESCRIPTION
A regular Github comment was being counted as a request, which was not intended behaviour.

This has been corrected.