### PR TITLE
Fix hardcoding of portal.cs.ubc.ca

### DIFF
--- a/src/controller/StaticHtmlController.ts
+++ b/src/controller/StaticHtmlController.ts
@@ -67,7 +67,7 @@ export default class StaticHtml {
           reject('Error creating Static Html Hyperlink ' + err);
         } else {
           Log.info('StaticHtmlController:: extractZipToDir() SUCCESS Extracted StaticHtml to ' + path);
-          fulfill('https://portal.cs.ubc.ca/static/' + that.newDirPath + '/html/');
+          fulfill('https://' + window.location.hostname + '/static/' + that.newDirPath + '/html/');
         }
        });
     });


### PR DESCRIPTION
Use window.location.hostname instead of portal.cs.ubc.ca

Make autotest portable from portal.cs.ubc.ca.
I'm not sure if there's a variable to use that would be better than this... but I believe this patch is necessary for the static html thing to work on the new servers (i.e. cs210.ugrad.cs.ubc.ca)